### PR TITLE
Config file for storing options

### DIFF
--- a/gbl2ngc.ini
+++ b/gbl2ngc.ini
@@ -1,49 +1,47 @@
 ; Radius of the V-cutter tool.
 ;radius = 0
-radius = 0.002
 
 ; Feedrate is how fast to move the tool when cutting. Decrease if your spindle RPM is slow or cut depth is deep
 ;feed = 10
 
 ; How fast should the tool move when not cutting. This can be much faster than the feedrate and is limited only by the machine's physical characteristics. Some programs call this a "rapid" movement.
 ;seek = 100
-seek = 300
 
 ; How far to lift the tool during a rapid/seek. Make sure to lift above any screws or fixtures holding the PCB to the table.
 ;zsafe = 0.1
 
 ; Position of the Z axis during cutting with respect to the top surface of the PCB. For example, a value of -0.005 will make the tool cut 50 thousandths into the copper.
-zcut = -0.002
+;zcut = -0.05
 
 ; Select prefered units. Set to 1 for metic and 0 for inches.
-;metric=0
+;metric=no
 
 ; Strip comments from the output GCODE
-;no-comment=0
+;no-comment=no
 
 ; Capitalize letters and strip comments whitespace from the output GCODE
-;machine-readable=0
+;machine-readable=no
 
 ; Route out blank areas with a horizontal scan line technique 
-;horizontal=0
+;horizontal=no
 
 ; Route out blank areas with a vertical scan line technique
-;vertical=0
+;vertical=no
 
 ; Route out blank areas with a zen garden technique
-;zengarden=0
+;zengarden=no
 
 ; Print polygon regions only (debug option)
-;print-polygon=0
+;print-polygon=no
 
 ; Invert the fill pattern (experimental)
-;invertfill=0
+;invertfill=no
 
 ; Infill copper polygons with pattern. Only -H and -V are currently supported.
-;simple-infill=0
+;simple-infill=no
 
 ; Do not route outlines when doing infill
-;no-outline=0
+;no-outline=no
 
 ; Output more information
-;verbose=0
+;verbose=no

--- a/gbl2ngc.ini
+++ b/gbl2ngc.ini
@@ -1,0 +1,33 @@
+; Radius of the V-cutter tool.
+;radius = 0
+radius = 0.002
+
+; Feedrate is how fast to move the tool when cutting. Decrease if your spindle RPM is slow or cut depth is deep
+;feed = 10
+
+; How fast should the tool move when not cutting. This can be much faster than the feedrate and is limited only by the machine's physical characteristics. Some programs call this a "rapid" movement.
+;seek = 100
+seek = 300
+
+; How far to lift the tool during a rapid/seek. Make sure to lift above any screws or fixtures holding the PCB to the table.
+;zsafe = 0.1
+
+; Position of the Z axis during cutting with respect to the top surface of the PCB. For example, a value of -0.005 will make the tool cut 50 thousandths into the copper.
+zcut = -0.002
+
+; Select prefered units. Set to 1 for metic and 0 for inches.
+;metric=0
+
+;no-comment=0
+;machine-readable=0
+
+;horizontal=0
+;vertical=0
+;vertical=0
+;
+;print-polygon=0
+;invertfill=0
+;simple-infill=0
+;no-outline=0
+;
+;verbose=0

--- a/gbl2ngc.ini
+++ b/gbl2ngc.ini
@@ -1,47 +1,63 @@
+; ==================================
+; === gbl2ngc CONFIGURATION FILE ===
+; ==================================
+;
+; Any options that appear in the command-line help message can be used here
+; with the long names. The default values for each option are shown in a 
+; comment. Either uncomment the option by deleting the semicolon before it OR
+; just retype the option on the next line if you wish to remember the default 
+; value. Don't forget the default values are also given in the help message.
+
 ; Radius of the V-cutter tool.
 ;radius = 0
 
-; Feedrate is how fast to move the tool when cutting. Decrease if your spindle RPM is slow or cut depth is deep
+; Feedrate is how fast to move the tool when cutting. Decrease if your spindle 
+; RPM is slow or cut depth is deep.
 ;feed = 10
 
-; How fast should the tool move when not cutting. This can be much faster than the feedrate and is limited only by the machine's physical characteristics. Some programs call this a "rapid" movement.
+; How fast should the tool move when not cutting. This can be much faster than 
+; the feedrate and is limited only by the machine's physical characteristics. 
+; Some programs call this a "rapid" movement.
 ;seek = 100
 
-; How far to lift the tool during a rapid/seek. Make sure to lift above any screws or fixtures holding the PCB to the table.
+; How far to lift the tool during a rapid/seek. Make sure to lift above any 
+; screws or fixtures holding the PCB to the table.
 ;zsafe = 0.1
 
-; Position of the Z axis during cutting with respect to the top surface of the PCB. For example, a value of -0.005 will make the tool cut 50 thousandths into the copper.
+; Position of the Z axis during cutting with respect to the top surface of the 
+; PCB. For example, a value of -0.005 will make the tool cut 50 thousandths 
+; into the copper.
 ;zcut = -0.05
 
-; Select prefered units. Set to 1 for metic and 0 for inches.
+; Select prefered units. Set to 'no' for inches.
 ;metric=no
 
-; Strip comments from the output GCODE
+; Strip comments from the output GCODE.
 ;no-comment=no
 
-; Capitalize letters and strip comments whitespace from the output GCODE
+; Capitalize letters and strip comments whitespace from the output GCODE.
 ;machine-readable=no
 
-; Route out blank areas with a horizontal scan line technique 
+; Route out blank areas with a horizontal scan line technique. 
 ;horizontal=no
 
-; Route out blank areas with a vertical scan line technique
+; Route out blank areas with a vertical scan line technique.
 ;vertical=no
 
-; Route out blank areas with a zen garden technique
+; Route out blank areas with a zen garden technique.
 ;zengarden=no
 
-; Print polygon regions only (debug option)
+; Print polygon regions only (debug option).
 ;print-polygon=no
 
-; Invert the fill pattern (experimental)
+; Invert the fill pattern (experimental).
 ;invertfill=no
 
 ; Infill copper polygons with pattern. Only -H and -V are currently supported.
 ;simple-infill=no
 
-; Do not route outlines when doing infill
+; Do not route outlines when doing infill.
 ;no-outline=no
 
-; Output more information
+; Output more detailed messages.
 ;verbose=no

--- a/gbl2ngc.ini
+++ b/gbl2ngc.ini
@@ -18,16 +18,32 @@ zcut = -0.002
 ; Select prefered units. Set to 1 for metic and 0 for inches.
 ;metric=0
 
+; Strip comments from the output GCODE
 ;no-comment=0
+
+; Capitalize letters and strip comments whitespace from the output GCODE
 ;machine-readable=0
 
+; Route out blank areas with a horizontal scan line technique 
 ;horizontal=0
+
+; Route out blank areas with a vertical scan line technique
 ;vertical=0
-;vertical=0
-;
+
+; Route out blank areas with a zen garden technique
+;zengarden=0
+
+; Print polygon regions only (debug option)
 ;print-polygon=0
+
+; Invert the fill pattern (experimental)
 ;invertfill=0
+
+; Infill copper polygons with pattern. Only -H and -V are currently supported.
 ;simple-infill=0
+
+; Do not route outlines when doing infill
 ;no-outline=0
-;
+
+; Output more information
 ;verbose=0

--- a/src/gbl2ngc.cpp
+++ b/src/gbl2ngc.cpp
@@ -20,7 +20,17 @@
 
 #include "gbl2ngc.hpp"
 
+// gbl2ngc will look here by default for a config file
 #define DEFAULT_CONFIG_FILENAME "./gbl2ngc.ini"
+
+// How should users specify boolean options?
+// i.e.
+//  - verbose = 1|0
+//  - verbose = yes|no
+//  - verbose = true|false
+//  - verbose = on|off
+#define CONFIG_FILE_YES "1"
+#define CONFIG_FILE_NO "0"
 
 struct option gLongOption[] =
 {
@@ -157,15 +167,40 @@ void show_help(void)
 
 }
 
+// Use as a go-between for the internal globals and optarg,
+// which could either come from a config file or be NULL if
+// the option was given as a command line switch.
+// `default_` is the value that is returned if the option is
+// set to CONFIG_FILE_YES or given as a CLI switch.
+bool bool_option(const char* optarg, bool default_ = true)
+{
+  if (optarg == NULL) {
+    return default_;
+  }
+
+  else if (strcmp(optarg, CONFIG_FILE_YES) == 0) {
+    return default_;
+  }
+
+  else if (strcmp(optarg, CONFIG_FILE_NO) == 0) {
+    return !default_;
+  }
+
+  // Treat all other values for optarg as NO
+  return !default_;
+}
+
 bool set_option(const char option_char, const char* optarg) 
 {
+  printf("set_option(%c, %s)\n", option_char, optarg);
+
   switch(option_char)
   {
     case 'C':
-      gShowComments = 0;
+      gShowComments = bool_option(optarg, 0);
       break;
     case 'R':
-      gHumanReadable = 0;
+      gHumanReadable = bool_option(optarg, 0);
       break;
     case 'r':
       gRadius = atof(optarg);
@@ -189,30 +224,30 @@ bool set_option(const char option_char, const char* optarg)
       gFeedRate = atoi(optarg);
       break;
     case 'I':
-      gMetricUnits = 0;
+      gMetricUnits = bool_option(optarg, 0);
       gUnitsDefault = 0;
       break;
     case 'M':
-      gMetricUnits = 1;
+      gMetricUnits = bool_option(optarg);
       gUnitsDefault = 0;
       break;
 
     case 'H':
-      gScanLineHorizontal = 1;
+      gScanLineHorizontal = bool_option(optarg);
       break;
     case 'V':
-      gScanLineVertical = 1;
+      gScanLineVertical = bool_option(optarg);
       break;
     case 'G':
-      gScanLineZenGarden = 1;
+      gScanLineZenGarden = bool_option(optarg);
       break;
 
     case 'P':
-      gPrintPolygon = 1;
+      gPrintPolygon = bool_option(optarg);
       break;
 
     case 'v':
-      gVerboseFlag = 1;
+      gVerboseFlag = bool_option(optarg);
       break;
     default:
       return false;

--- a/src/gbl2ngc.cpp
+++ b/src/gbl2ngc.cpp
@@ -20,6 +20,7 @@
 
 #include "gbl2ngc.hpp"
 
+#define DEFAULT_CONFIG_FILENAME "./gbl2ngc.ini"
 
 struct option gLongOption[] =
 {
@@ -224,15 +225,20 @@ bool set_option(const char option_char, const char* optarg)
 void process_config_file_options() {
 
   if (!gConfigFilename) {
-    // gConfigFilename = strdup("./gbl2ngc.ini");
+    gConfigFilename = strdup(DEFAULT_CONFIG_FILENAME);
   }
 
-  fprintf(stdout, "using config file: %s\n", gConfigFilename);
-
   if (! (gCfgStream = fopen(gConfigFilename, "r"))) {
+    if (strcmp(gConfigFilename, DEFAULT_CONFIG_FILENAME) == 0) {
+      return;
+    }
+    
+    fprintf(stderr, "Can't load configuration: ");
     perror(gOutputFilename);
     exit(1);
   }
+
+  fprintf(stdout, "Using configuration: %s\n", gConfigFilename);
 
   char option_name[64];
   char option_value[64];
@@ -257,12 +263,12 @@ void process_config_file_options() {
       strncpy(option_name, line, name_end - line);
       strncpy(option_value, value_start, strlen(value_start)-1);
 
-      printf("|%s=%s|\n", option_name, option_value);
-      
       const char option_char = lookup_option_by_name(option_name).val;
       set_option(option_char, option_value);
     }
   }
+
+  fclose(gCfgStream);
 }
 
 void process_command_line_options(int argc, char **argv)
@@ -384,7 +390,6 @@ void process_command_line_options(int argc, char **argv)
 
 void cleanup(void)
 {
-  fclose(gCfgStream);
   if (gOutStream != stdout)
     fclose(gOutStream);
   if (gOutputFilename)

--- a/src/gbl2ngc.cpp
+++ b/src/gbl2ngc.cpp
@@ -29,8 +29,8 @@
 //  - verbose = yes|no
 //  - verbose = true|false
 //  - verbose = on|off
-#define CONFIG_FILE_YES "1"
-#define CONFIG_FILE_NO "0"
+#define CONFIG_FILE_YES "yes"
+#define CONFIG_FILE_NO "no"
 
 struct option gLongOption[] =
 {

--- a/src/gbl2ngc.hpp
+++ b/src/gbl2ngc.hpp
@@ -89,6 +89,7 @@ extern int gMetricUnits;
 extern int gUnitsDefault;
 extern char *gInputFilename;
 extern char *gOutputFilename;
+extern char *gConfigFilename;
 extern int gFeedRate;
 extern int gSeekRate;
 
@@ -105,6 +106,7 @@ extern double gZCut;
 
 extern FILE *gOutStream;
 extern FILE *gInpStream;
+extern FILE *gCfgStream;
 
 extern double eps;
 extern double gRadius;

--- a/src/gbl2ngc_debug.cpp
+++ b/src/gbl2ngc_debug.cpp
@@ -335,3 +335,28 @@ void print_profile(struct timeval *tv0, struct timeval *tv1)
 }
 
 
+void dump_options() {
+  printf("input = %s\n", gInputFilename);
+  printf("output = %s\n", gOutputFilename);
+  // printf("config-file = %s", gConfigFilename);
+
+  printf("radius = %f\n", gRadius);
+  printf("fillradius = %f\n", gFillRadius);
+
+  printf("feed = %d\n", gFeedRate);
+  printf("seek = %d\n", gSeekRate);
+
+  printf("zsafe = %f\n", gZSafe);
+  printf("zcut = %f\n", gZCut);
+
+  printf("metric = %d\n", gMetricUnits);
+
+  printf("no-comment = %d\n", !gShowComments);
+  printf("machine-readable = %d\n", !gHumanReadable);
+
+  printf("horizinal = %d\n", gScanLineHorizontal);
+  printf("vertical = %d\n", gScanLineVertical);
+  printf("zengarden = %d\n", gScanLineZenGarden);
+
+  printf("verbose = %d\n", gVerboseFlag);
+}

--- a/src/gbl2ngc_globals.cpp
+++ b/src/gbl2ngc_globals.cpp
@@ -25,6 +25,7 @@ int gMetricUnits = 0;
 int gUnitsDefault = 1;
 char *gInputFilename = NULL;
 char *gOutputFilename = NULL;
+char *gConfigFilename = NULL;
 int gFeedRate = 10;
 int gSeekRate = 100;
 
@@ -41,6 +42,7 @@ double gZCut = -0.05;
 
 FILE *gOutStream = stdout;
 FILE *gInpStream = stdin;
+FILE *gCfgStream;
 
 double eps = 0.000001;
 double gRadius = 0.0;


### PR DESCRIPTION
Hello @abetusk! I stumbled upon gbl2ngc a few days ago and was impressed. I've often felt that open source CAM or CNC software has been lacking and I appreciate the work you've done. I love the simplicity of gbl2ngc's command-line interface, but as gbl2ngc grows in capability, I think it makes sense to have a place for users to store their settings. 
That is the purpose of this PR - a config file that uses a simple `.ini` format where the names of the options are identical to the command-line long options.

To make the config file more user friendly, I included a short description and the default value with each option, like this:

```ini
; This is what this options does.
;seek = 100
```

By default, gbl2ngc looks for a file named `gbl2ngc.ini` in the current directory. If it exists, it will load up the config. If not, it will continue on as normal. The user may optionally specify a custom location of a config file with the `-c, --config-file` option.

You'll notice that `gbl2ngc.cpp` has changed a bit, especially the `process_command_line options()` function. That is because the `-c` needs to be checked prior to all the other options to ensure that config file options are always loaded before the user's command line options are applied, otherwise the user could not override the config file. 

I know that this PR does not close an issue, but if you see the benefits, I'd be thrilled to see this feature merged. I did my best to match my code with your style, but I'd appreciate a review. Test it out yourself and see if you come across any issues or have any additional concerns. Once again, great job on this software!