### PR TITLE
Add options for exporting extra G-code blocks

### DIFF
--- a/gbl2ngc.ini
+++ b/gbl2ngc.ini
@@ -1,49 +1,47 @@
 ; Radius of the V-cutter tool.
 ;radius = 0
-radius = 0.002
 
 ; Feedrate is how fast to move the tool when cutting. Decrease if your spindle RPM is slow or cut depth is deep
 ;feed = 10
 
 ; How fast should the tool move when not cutting. This can be much faster than the feedrate and is limited only by the machine's physical characteristics. Some programs call this a "rapid" movement.
 ;seek = 100
-seek = 300
 
 ; How far to lift the tool during a rapid/seek. Make sure to lift above any screws or fixtures holding the PCB to the table.
 ;zsafe = 0.1
 
 ; Position of the Z axis during cutting with respect to the top surface of the PCB. For example, a value of -0.005 will make the tool cut 50 thousandths into the copper.
-zcut = -0.002
+;zcut = -0.05
 
 ; Select prefered units. Set to 1 for metic and 0 for inches.
-;metric=0
+;metric=no
 
 ; Strip comments from the output GCODE
-;no-comment=0
+;no-comment=no
 
 ; Capitalize letters and strip comments whitespace from the output GCODE
-;machine-readable=0
+;machine-readable=no
 
 ; Route out blank areas with a horizontal scan line technique 
-;horizontal=0
+;horizontal=no
 
 ; Route out blank areas with a vertical scan line technique
-;vertical=0
+;vertical=no
 
 ; Route out blank areas with a zen garden technique
-;zengarden=0
+;zengarden=no
 
 ; Print polygon regions only (debug option)
-;print-polygon=0
+;print-polygon=no
 
 ; Invert the fill pattern (experimental)
-;invertfill=0
+;invertfill=no
 
 ; Infill copper polygons with pattern. Only -H and -V are currently supported.
-;simple-infill=0
+;simple-infill=no
 
 ; Do not route outlines when doing infill
-;no-outline=0
+;no-outline=no
 
 ; Output more information
-;verbose=0
+;verbose=no

--- a/gbl2ngc.ini
+++ b/gbl2ngc.ini
@@ -1,0 +1,33 @@
+; Radius of the V-cutter tool.
+;radius = 0
+radius = 0.002
+
+; Feedrate is how fast to move the tool when cutting. Decrease if your spindle RPM is slow or cut depth is deep
+;feed = 10
+
+; How fast should the tool move when not cutting. This can be much faster than the feedrate and is limited only by the machine's physical characteristics. Some programs call this a "rapid" movement.
+;seek = 100
+seek = 300
+
+; How far to lift the tool during a rapid/seek. Make sure to lift above any screws or fixtures holding the PCB to the table.
+;zsafe = 0.1
+
+; Position of the Z axis during cutting with respect to the top surface of the PCB. For example, a value of -0.005 will make the tool cut 50 thousandths into the copper.
+zcut = -0.002
+
+; Select prefered units. Set to 1 for metic and 0 for inches.
+;metric=0
+
+;no-comment=0
+;machine-readable=0
+
+;horizontal=0
+;vertical=0
+;vertical=0
+;
+;print-polygon=0
+;invertfill=0
+;simple-infill=0
+;no-outline=0
+;
+;verbose=0

--- a/gbl2ngc.ini
+++ b/gbl2ngc.ini
@@ -1,47 +1,63 @@
+; ==================================
+; === gbl2ngc CONFIGURATION FILE ===
+; ==================================
+;
+; Any options that appear in the command-line help message can be used here
+; with the long names. The default values for each option are shown in a 
+; comment. Either uncomment the option by deleting the semicolon before it OR
+; just retype the option on the next line if you wish to remember the default 
+; value. Don't forget the default values are also given in the help message.
+
 ; Radius of the V-cutter tool.
 ;radius = 0
 
-; Feedrate is how fast to move the tool when cutting. Decrease if your spindle RPM is slow or cut depth is deep
+; Feedrate is how fast to move the tool when cutting. Decrease if your spindle 
+; RPM is slow or cut depth is deep.
 ;feed = 10
 
-; How fast should the tool move when not cutting. This can be much faster than the feedrate and is limited only by the machine's physical characteristics. Some programs call this a "rapid" movement.
+; How fast should the tool move when not cutting. This can be much faster than 
+; the feedrate and is limited only by the machine's physical characteristics. 
+; Some programs call this a "rapid" movement.
 ;seek = 100
 
-; How far to lift the tool during a rapid/seek. Make sure to lift above any screws or fixtures holding the PCB to the table.
+; How far to lift the tool during a rapid/seek. Make sure to lift above any 
+; screws or fixtures holding the PCB to the table.
 ;zsafe = 0.1
 
-; Position of the Z axis during cutting with respect to the top surface of the PCB. For example, a value of -0.005 will make the tool cut 50 thousandths into the copper.
+; Position of the Z axis during cutting with respect to the top surface of the 
+; PCB. For example, a value of -0.005 will make the tool cut 50 thousandths 
+; into the copper.
 ;zcut = -0.05
 
-; Select prefered units. Set to 1 for metic and 0 for inches.
+; Select prefered units. Set to 'no' for inches.
 ;metric=no
 
-; Strip comments from the output GCODE
+; Strip comments from the output GCODE.
 ;no-comment=no
 
-; Capitalize letters and strip comments whitespace from the output GCODE
+; Capitalize letters and strip comments whitespace from the output GCODE.
 ;machine-readable=no
 
-; Route out blank areas with a horizontal scan line technique 
+; Route out blank areas with a horizontal scan line technique. 
 ;horizontal=no
 
-; Route out blank areas with a vertical scan line technique
+; Route out blank areas with a vertical scan line technique.
 ;vertical=no
 
-; Route out blank areas with a zen garden technique
+; Route out blank areas with a zen garden technique.
 ;zengarden=no
 
-; Print polygon regions only (debug option)
+; Print polygon regions only (debug option).
 ;print-polygon=no
 
-; Invert the fill pattern (experimental)
+; Invert the fill pattern (experimental).
 ;invertfill=no
 
 ; Infill copper polygons with pattern. Only -H and -V are currently supported.
 ;simple-infill=no
 
-; Do not route outlines when doing infill
+; Do not route outlines when doing infill.
 ;no-outline=no
 
-; Output more information
+; Output more detailed messages.
 ;verbose=no

--- a/gbl2ngc.ini
+++ b/gbl2ngc.ini
@@ -18,16 +18,32 @@ zcut = -0.002
 ; Select prefered units. Set to 1 for metic and 0 for inches.
 ;metric=0
 
+; Strip comments from the output GCODE
 ;no-comment=0
+
+; Capitalize letters and strip comments whitespace from the output GCODE
 ;machine-readable=0
 
+; Route out blank areas with a horizontal scan line technique 
 ;horizontal=0
+
+; Route out blank areas with a vertical scan line technique
 ;vertical=0
-;vertical=0
-;
+
+; Route out blank areas with a zen garden technique
+;zengarden=0
+
+; Print polygon regions only (debug option)
 ;print-polygon=0
+
+; Invert the fill pattern (experimental)
 ;invertfill=0
+
+; Infill copper polygons with pattern. Only -H and -V are currently supported.
 ;simple-infill=0
+
+; Do not route outlines when doing infill
 ;no-outline=0
-;
+
+; Output more information
 ;verbose=0

--- a/gbl2ngc.ini
+++ b/gbl2ngc.ini
@@ -3,29 +3,29 @@
 ; ==================================
 ;
 ; Any options that appear in the command-line help message can be used here
-; with the long names. The default values for each option are shown in a 
+; with the long names. The default values for each option are shown in a
 ; comment. Either uncomment the option by deleting the semicolon before it OR
-; just retype the option on the next line if you wish to remember the default 
+; just retype the option on the next line if you wish to remember the default
 ; value. Don't forget the default values are also given in the help message.
 
 ; Radius of the V-cutter tool.
 ;radius = 0
 
-; Feedrate is how fast to move the tool when cutting. Decrease if your spindle 
+; Feedrate is how fast to move the tool when cutting. Decrease if your spindle
 ; RPM is slow or cut depth is deep.
 ;feed = 10
 
-; How fast should the tool move when not cutting. This can be much faster than 
-; the feedrate and is limited only by the machine's physical characteristics. 
+; How fast should the tool move when not cutting. This can be much faster than
+; the feedrate and is limited only by the machine's physical characteristics.
 ; Some programs call this a "rapid" movement.
 ;seek = 100
 
-; How far to lift the tool during a rapid/seek. Make sure to lift above any 
+; How far to lift the tool during a rapid/seek. Make sure to lift above any
 ; screws or fixtures holding the PCB to the table.
 ;zsafe = 0.1
 
-; Position of the Z axis during cutting with respect to the top surface of the 
-; PCB. For example, a value of -0.005 will make the tool cut 50 thousandths 
+; Position of the Z axis during cutting with respect to the top surface of the
+; PCB. For example, a value of -0.005 will make the tool cut 50 thousandths
 ; into the copper.
 ;zcut = -0.05
 
@@ -38,7 +38,7 @@
 ; Capitalize letters and strip comments whitespace from the output GCODE.
 ;machine-readable=no
 
-; Route out blank areas with a horizontal scan line technique. 
+; Route out blank areas with a horizontal scan line technique.
 ;horizontal=no
 
 ; Route out blank areas with a vertical scan line technique.

--- a/src/gbl2ngc.cpp
+++ b/src/gbl2ngc.cpp
@@ -32,6 +32,13 @@
 #define CONFIG_FILE_YES "yes"
 #define CONFIG_FILE_NO "no"
 
+// There are only 26 letters in the alphabet; 52 including uppercase. As the
+// program grows in complexity and cabability, the letter choices available
+// for command-line arguments will get slim. One solution is to assign numbers
+// instead of letters for less-commonly used or advanced options.
+#define ARG_GCODE_HEADER 2
+#define ARG_GCODE_FOOTER 3
+
 struct option gLongOption[] =
 {
   {"radius" , required_argument , 0, 'r'},
@@ -47,6 +54,9 @@ struct option gLongOption[] =
 
   {"zsafe"  , required_argument , 0, 'z'},
   {"zcut"   , required_argument , 0, 'Z'},
+
+  {"gcode-header", required_argument, 0, ARG_GCODE_HEADER},
+  {"gcode-footer", required_argument, 0, ARG_GCODE_FOOTER},
 
   {"metric" , no_argument       , 0, 'M'},
   {"inches" , no_argument       , 0, 'I'},
@@ -88,6 +98,9 @@ char gOptionDescription[][1024] =
 
   "z safe height (default 0.1 inches)",
   "z cut height (default -0.05 inches)",
+
+  "prepend custom G-code to the beginning of the program",
+  "append custom G-code to the end of the program",
 
   "units in metric",
   "units in inches",
@@ -223,6 +236,13 @@ bool set_option(const char option_char, const char* optarg)
     case 'f':
       gFeedRate = atoi(optarg);
       break;
+    
+    case ARG_GCODE_HEADER:
+      gGCodeHeader = strdup(optarg);
+      break;
+    case ARG_GCODE_FOOTER:
+      gGCodeFooter = strdup(optarg);
+
     case 'I':
       gMetricUnits = bool_option(optarg, 0);
       gUnitsDefault = 0;

--- a/src/gbl2ngc.cpp
+++ b/src/gbl2ngc.cpp
@@ -20,7 +20,17 @@
 
 #include "gbl2ngc.hpp"
 
+// gbl2ngc will look here by default for a config file
 #define DEFAULT_CONFIG_FILENAME "./gbl2ngc.ini"
+
+// How should users specify boolean options?
+// i.e.
+//  - verbose = 1|0
+//  - verbose = yes|no
+//  - verbose = true|false
+//  - verbose = on|off
+#define CONFIG_FILE_YES "1"
+#define CONFIG_FILE_NO "0"
 
 struct option gLongOption[] =
 {
@@ -157,15 +167,40 @@ void show_help(void)
 
 }
 
+// Use as a go-between for the internal globals and optarg,
+// which could either come from a config file or be NULL if
+// the option was given as a command line switch.
+// `default_` is the value that is returned if the option is
+// set to CONFIG_FILE_YES or given as a CLI switch.
+bool bool_option(const char* optarg, bool default_ = true)
+{
+  if (optarg == NULL) {
+    return default_;
+  }
+
+  else if (strcmp(optarg, CONFIG_FILE_YES) == 0) {
+    return default_;
+  }
+
+  else if (strcmp(optarg, CONFIG_FILE_NO) == 0) {
+    return !default_;
+  }
+
+  // Treat all other values for optarg as NO
+  return !default_;
+}
+
 bool set_option(const char option_char, const char* optarg) 
 {
+  printf("set_option(%c, %s)\n", option_char, optarg);
+
   switch(option_char)
   {
     case 'C':
-      gShowComments = 0;
+      gShowComments = bool_option(optarg, 0);
       break;
     case 'R':
-      gHumanReadable = 0;
+      gHumanReadable = bool_option(optarg, 0);
       break;
     case 'r':
       gRadius = atof(optarg);
@@ -189,30 +224,30 @@ bool set_option(const char option_char, const char* optarg)
       gFeedRate = atoi(optarg);
       break;
     case 'I':
-      gMetricUnits = 0;
+      gMetricUnits = bool_option(optarg, 0);
       gUnitsDefault = 0;
       break;
     case 'M':
-      gMetricUnits = 1;
+      gMetricUnits = bool_option(optarg);
       gUnitsDefault = 0;
       break;
 
     case 'H':
-      gScanLineHorizontal = 1;
+      gScanLineHorizontal = bool_option(optarg);
       break;
     case 'V':
-      gScanLineVertical = 1;
+      gScanLineVertical = bool_option(optarg);
       break;
     case 'G':
-      gScanLineZenGarden = 1;
+      gScanLineZenGarden = bool_option(optarg);
       break;
 
     case 'P':
-      gPrintPolygon = 1;
+      gPrintPolygon = bool_option(optarg);
       break;
 
     case 'v':
-      gVerboseFlag = 1;
+      gVerboseFlag = bool_option(optarg);
       break;
     default:
       return false;

--- a/src/gbl2ngc.cpp
+++ b/src/gbl2ngc.cpp
@@ -23,19 +23,18 @@
 // gbl2ngc will look here by default for a config file
 #define DEFAULT_CONFIG_FILENAME "./gbl2ngc.ini"
 
-// How should users specify boolean options?
-// i.e.
-//  - verbose = 1|0
+// Users should specify boolean options as "yes" or "no"
+// (without quotes).
+//
+// e.g.
 //  - verbose = yes|no
-//  - verbose = true|false
-//  - verbose = on|off
+//
 #define CONFIG_FILE_YES "yes"
 #define CONFIG_FILE_NO "no"
 
 struct option gLongOption[] =
 {
   {"radius" , required_argument , 0, 'r'},
-  //{"routeradius" , required_argument , 0, 'R'},
   {"fillradius" , required_argument , 0, 'F'},
 
   {"input"  , required_argument , 0, 'i'},
@@ -76,7 +75,6 @@ struct option gLongOption[] =
 char gOptionDescription[][1024] =
 {
   "radius (default 0)",
-  //"radius to be used for routing (default to radius above)",
   "radius to be used for fill pattern (default to radius above)",
 
   "input file",
@@ -190,9 +188,7 @@ bool bool_option(const char* optarg, bool default_ = true)
   return !default_;
 }
 
-bool set_option(const char option_char, const char* optarg) 
-{
-  printf("set_option(%c, %s)\n", option_char, optarg);
+bool set_option(const char option_char, const char* optarg) {
 
   switch(option_char)
   {
@@ -267,20 +263,18 @@ void process_config_file_options() {
     if (strcmp(gConfigFilename, DEFAULT_CONFIG_FILENAME) == 0) {
       return;
     }
-    
+
     fprintf(stderr, "Can't load configuration: ");
     perror(gOutputFilename);
     exit(1);
   }
-
-  fprintf(stdout, "Using configuration: %s\n", gConfigFilename);
 
   char option_name[64];
   char option_value[64];
   char line[256] = {'\0'};
 
   while (fgets(line, sizeof(line), gCfgStream)) {
-    
+
     if (strcmp(line, "\n") == 0) {
       // printf("skipping blank line");
     }
@@ -360,7 +354,7 @@ void process_command_line_options(int argc, char **argv)
       case 'c':
         // Do nothing, but don't go to default!
         break;
-      
+
       default:
         if (!set_option(ch, optarg)) {
           printf("bad option: -%c %s\n", ch, optarg);
@@ -369,7 +363,7 @@ void process_command_line_options(int argc, char **argv)
         }
         break;
     }
-    
+
   }
 
   if (gFillRadius <= 0.0)
@@ -853,7 +847,7 @@ int main(int argc, char **argv)
 
   Paths pgn_union;
   Paths offset;
-  
+
   process_command_line_options(argc, argv);
   // dump_options();
 

--- a/src/gbl2ngc.cpp
+++ b/src/gbl2ngc.cpp
@@ -20,6 +20,7 @@
 
 #include "gbl2ngc.hpp"
 
+#define DEFAULT_CONFIG_FILENAME "./gbl2ngc.ini"
 
 struct option gLongOption[] =
 {
@@ -224,15 +225,20 @@ bool set_option(const char option_char, const char* optarg)
 void process_config_file_options() {
 
   if (!gConfigFilename) {
-    // gConfigFilename = strdup("./gbl2ngc.ini");
+    gConfigFilename = strdup(DEFAULT_CONFIG_FILENAME);
   }
 
-  fprintf(stdout, "using config file: %s\n", gConfigFilename);
-
   if (! (gCfgStream = fopen(gConfigFilename, "r"))) {
+    if (strcmp(gConfigFilename, DEFAULT_CONFIG_FILENAME) == 0) {
+      return;
+    }
+    
+    fprintf(stderr, "Can't load configuration: ");
     perror(gOutputFilename);
     exit(1);
   }
+
+  fprintf(stdout, "Using configuration: %s\n", gConfigFilename);
 
   char option_name[64];
   char option_value[64];
@@ -257,12 +263,12 @@ void process_config_file_options() {
       strncpy(option_name, line, name_end - line);
       strncpy(option_value, value_start, strlen(value_start)-1);
 
-      printf("|%s=%s|\n", option_name, option_value);
-      
       const char option_char = lookup_option_by_name(option_name).val;
       set_option(option_char, option_value);
     }
   }
+
+  fclose(gCfgStream);
 }
 
 void process_command_line_options(int argc, char **argv)
@@ -384,7 +390,6 @@ void process_command_line_options(int argc, char **argv)
 
 void cleanup(void)
 {
-  fclose(gCfgStream);
   if (gOutStream != stdout)
     fclose(gOutStream);
   if (gOutputFilename)

--- a/src/gbl2ngc.cpp
+++ b/src/gbl2ngc.cpp
@@ -29,8 +29,8 @@
 //  - verbose = yes|no
 //  - verbose = true|false
 //  - verbose = on|off
-#define CONFIG_FILE_YES "1"
-#define CONFIG_FILE_NO "0"
+#define CONFIG_FILE_YES "yes"
+#define CONFIG_FILE_NO "no"
 
 struct option gLongOption[] =
 {

--- a/src/gbl2ngc.cpp
+++ b/src/gbl2ngc.cpp
@@ -447,6 +447,11 @@ void cleanup(void)
     free(gInputFilename);
   if (gConfigFilename)
     free(gConfigFilename);
+
+  if (gGCodeHeader)
+    free(gGCodeHeader);
+  if (gGCodeFooter)
+    free(gGCodeFooter);
 }
 
 

--- a/src/gbl2ngc.cpp
+++ b/src/gbl2ngc.cpp
@@ -32,6 +32,13 @@
 #define CONFIG_FILE_YES "yes"
 #define CONFIG_FILE_NO "no"
 
+// There are only 26 letters in the alphabet; 52 including uppercase. As the
+// program grows in complexity and cabability, the letter choices available
+// for command-line arguments will get slim. One solution is to assign numbers
+// instead of letters for less-commonly used or advanced options.
+#define ARG_GCODE_HEADER 2
+#define ARG_GCODE_FOOTER 3
+
 struct option gLongOption[] =
 {
   {"radius" , required_argument , 0, 'r'},
@@ -46,6 +53,9 @@ struct option gLongOption[] =
 
   {"zsafe"  , required_argument , 0, 'z'},
   {"zcut"   , required_argument , 0, 'Z'},
+
+  {"gcode-header", required_argument, 0, ARG_GCODE_HEADER},
+  {"gcode-footer", required_argument, 0, ARG_GCODE_FOOTER},
 
   {"metric" , no_argument       , 0, 'M'},
   {"inches" , no_argument       , 0, 'I'},
@@ -86,6 +96,9 @@ char gOptionDescription[][1024] =
 
   "z safe height (default 0.1 inches)",
   "z cut height (default -0.05 inches)",
+
+  "prepend custom G-code to the beginning of the program",
+  "append custom G-code to the end of the program",
 
   "units in metric",
   "units in inches",
@@ -219,6 +232,13 @@ bool set_option(const char option_char, const char* optarg) {
     case 'f':
       gFeedRate = atoi(optarg);
       break;
+    
+    case ARG_GCODE_HEADER:
+      gGCodeHeader = strdup(optarg);
+      break;
+    case ARG_GCODE_FOOTER:
+      gGCodeFooter = strdup(optarg);
+
     case 'I':
       gMetricUnits = bool_option(optarg, 0);
       gUnitsDefault = 0;

--- a/src/gbl2ngc.cpp
+++ b/src/gbl2ngc.cpp
@@ -453,6 +453,11 @@ void cleanup(void)
     free(gInputFilename);
   if (gConfigFilename)
     free(gConfigFilename);
+
+  if (gGCodeHeader)
+    free(gGCodeHeader);
+  if (gGCodeFooter)
+    free(gGCodeFooter);
 }
 
 

--- a/src/gbl2ngc.hpp
+++ b/src/gbl2ngc.hpp
@@ -30,7 +30,7 @@
 
 #include <math.h>
 
-#define GBL2NGC_VERSION "0.7.1"
+#define GBL2NGC_VERSION "0.7.2"
 
 extern "C" {
   #include "gerber_interpreter.h"

--- a/src/gbl2ngc.hpp
+++ b/src/gbl2ngc.hpp
@@ -89,6 +89,7 @@ extern int gMetricUnits;
 extern int gUnitsDefault;
 extern char *gInputFilename;
 extern char *gOutputFilename;
+extern char *gConfigFilename;
 extern int gFeedRate;
 extern int gSeekRate;
 
@@ -105,6 +106,7 @@ extern double gZCut;
 
 extern FILE *gOutStream;
 extern FILE *gInpStream;
+extern FILE *gCfgStream;
 
 extern double eps;
 extern double gRadius;

--- a/src/gbl2ngc.hpp
+++ b/src/gbl2ngc.hpp
@@ -87,9 +87,13 @@ typedef std::pair<int, Aperture_realization> ApertureNameMapPair;
 extern int gVerboseFlag;
 extern int gMetricUnits;
 extern int gUnitsDefault;
+
 extern char *gInputFilename;
 extern char *gOutputFilename;
 extern char *gConfigFilename;
+extern char *gGCodeHeader;
+extern char *gGCodeFooter;
+
 extern int gFeedRate;
 extern int gSeekRate;
 

--- a/src/gbl2ngc_construct.cpp
+++ b/src/gbl2ngc_construct.cpp
@@ -251,6 +251,7 @@ int construct_contour_region( PathSet &pwh_vec, contour_ll_t *contour ) {
 
   pwh_vec.push_back( soln );
 
+  if (!res) { return -1; }
   return 0;
 }
 

--- a/src/gbl2ngc_debug.cpp
+++ b/src/gbl2ngc_debug.cpp
@@ -335,3 +335,28 @@ void print_profile(struct timeval *tv0, struct timeval *tv1)
 }
 
 
+void dump_options() {
+  printf("input = %s\n", gInputFilename);
+  printf("output = %s\n", gOutputFilename);
+  // printf("config-file = %s", gConfigFilename);
+
+  printf("radius = %f\n", gRadius);
+  printf("fillradius = %f\n", gFillRadius);
+
+  printf("feed = %d\n", gFeedRate);
+  printf("seek = %d\n", gSeekRate);
+
+  printf("zsafe = %f\n", gZSafe);
+  printf("zcut = %f\n", gZCut);
+
+  printf("metric = %d\n", gMetricUnits);
+
+  printf("no-comment = %d\n", !gShowComments);
+  printf("machine-readable = %d\n", !gHumanReadable);
+
+  printf("horizinal = %d\n", gScanLineHorizontal);
+  printf("vertical = %d\n", gScanLineVertical);
+  printf("zengarden = %d\n", gScanLineZenGarden);
+
+  printf("verbose = %d\n", gVerboseFlag);
+}

--- a/src/gbl2ngc_export.cpp
+++ b/src/gbl2ngc_export.cpp
@@ -96,7 +96,10 @@ void export_paths_to_gcode_unit( FILE *ofp, Paths &paths, int src_units_0in_1mm,
     }
   }
 
-  //fprintf(ofp, "%s\n", gBlockHeader);
+  if (gGCodeHeader) {
+    fprintf(ofp, "%s\n", gGCodeHeader);
+  }
+  
 
   if (gHumanReadable) {
     fprintf(ofp, "f%i\n", gFeedRate);
@@ -158,7 +161,9 @@ void export_paths_to_gcode_unit( FILE *ofp, Paths &paths, int src_units_0in_1mm,
     fprintf(ofp, "\n\n");
   }
 
-  //fprintf(ofp, "%s\n", gBlockFooter);
+  if (gGCodeFooter) {
+    fprintf(ofp, "%s\n", gGCodeFooter);
+  }
 
 }
 

--- a/src/gbl2ngc_export.cpp
+++ b/src/gbl2ngc_export.cpp
@@ -20,6 +20,10 @@
 
 #include "gbl2ngc.hpp"
 
+// How many digits after the decimal point?
+// Yes, it should be a string :)
+#define GCODE_LENGTH_PRECISION "6"  
+
 static double unit_mm2in(double v) {
   return v/25.4;
 }
@@ -31,6 +35,50 @@ static double unit_in2mm(double v) {
 static double unit_identity(double v) {
   return v;
 }
+
+// Export a rapid (G0) movement to file.
+// `axes` is a string containing the letters of the axes to move.
+// Up to three axis coordinates can be provided.
+// Ex: rapid(f, "xz", 3, -5) will move X3 and Y-5
+void rapid(FILE* file, const char* axes, double one, double two=0, double three=0) {
+  int i;
+  double coords[] = {one, two, three};
+  
+  if (gHumanReadable) {
+    fprintf(file, "g0");  
+    for (i = 0; axes[i] != '\0'; i++) {
+      fprintf(file, " %c%." GCODE_LENGTH_PRECISION "f", tolower(axes[i]), coords[i]);
+    }  
+  } else {
+    fprintf(file, "G00");
+    for (i = 0; axes[i] != '\0'; i++) {
+      fprintf(file, "%c%." GCODE_LENGTH_PRECISION "f", toupper(axes[i]), coords[i]);
+    }
+  }
+
+  fprintf(file, "\n");
+}
+
+// G1 equiv. of rapid()
+void cut(FILE* file, const char* axes, double one, double two=0, double three=0) {
+  int i;
+  double coords[] = {one, two, three};
+  
+  if (gHumanReadable) {
+    fprintf(file, "g1");  
+    for (i = 0; axes[i] != '\0'; i++) {
+      fprintf(file, " %c%." GCODE_LENGTH_PRECISION "f", tolower(axes[i]), coords[i]);
+    }  
+  } else {
+    fprintf(file, "G01");
+    for (i = 0; axes[i] != '\0'; i++) {
+      fprintf(file, "%c%." GCODE_LENGTH_PRECISION "f", toupper(axes[i]), coords[i]);
+    }
+  }
+
+  fprintf(file, "\n");
+}
+
 
 void export_paths_to_gcode_unit( FILE *ofp, Paths &paths, int src_units_0in_1mm, int dst_units_0in_1mm)
 {
@@ -48,13 +96,15 @@ void export_paths_to_gcode_unit( FILE *ofp, Paths &paths, int src_units_0in_1mm,
     }
   }
 
+  //fprintf(ofp, "%s\n", gBlockHeader);
+
   if (gHumanReadable) {
     fprintf(ofp, "f%i\n", gFeedRate);
-    fprintf(ofp, "g1 z%f", gZSafe);
   } else {
     fprintf(ofp, "F%i\n", gFeedRate);
-    fprintf(ofp, "G01Z%f\n", gZSafe);
   }
+
+  rapid(ofp, "z", gZSafe);
 
   if (gHumanReadable) {
     fprintf(ofp, "\n");
@@ -80,47 +130,35 @@ void export_paths_to_gcode_unit( FILE *ofp, Paths &paths, int src_units_0in_1mm,
     m = paths[i].size();
     for (j=0; j<m; j++)
     {
+      double x = f(ctod( paths[i][j].X ));
+      double y = f(ctod( paths[i][j].Y ));
+
       if (first)
       {
-
-        if (gHumanReadable) {
-          fprintf(ofp, "g0 x%f y%f\n", f(ctod( paths[i][j].X )), f(ctod( paths[i][j].Y )) );
-          fprintf(ofp, "g1 z%f\n", gZCut);
-        } else {
-          fprintf(ofp, "G00X%fY%f\n", f(ctod( paths[i][j].X )), f(ctod( paths[i][j].Y )) );
-          fprintf(ofp, "G01Z%f\n", gZCut);
-        }
+        rapid(ofp, "xy", x, y);
+        cut(ofp, "z", gZCut);
 
         first = 0;
       }
       else
       {
-
-        if (gHumanReadable) {
-          fprintf(ofp, "g1 x%f y%f\n", f(ctod( paths[i][j].X )), f(ctod( paths[i][j].Y )) );
-        } else {
-          fprintf(ofp, "G01X%fY%f\n", f(ctod( paths[i][j].X )), f(ctod( paths[i][j].Y )) );
-        }
-
+        cut(ofp, "xy", x, y);
       }
-
     }
 
     // go back to start
     //
-    if (gHumanReadable) {
-      fprintf(ofp, "g1 x%f y%f\n", f(ctod( paths[i][0].X )), f(ctod( paths[i][0].Y )) );
-      fprintf(ofp, "g1 z%f\n", gZSafe);
-    } else {
-      fprintf(ofp, "G01X%fY%f\n", f(ctod( paths[i][0].X )), f(ctod( paths[i][0].Y )) );
-      fprintf(ofp, "G01Z%f\n", gZSafe);
-    }
-
+    double start_x = f(ctod( paths[i][0].X));
+    double start_y = f(ctod( paths[i][0].Y));
+    cut(ofp, "xy", start_x, start_y);
+    cut(ofp, "z", gZSafe);
   }
 
   if (gHumanReadable) {
     fprintf(ofp, "\n\n");
   }
+
+  //fprintf(ofp, "%s\n", gBlockFooter);
 
 }
 

--- a/src/gbl2ngc_globals.cpp
+++ b/src/gbl2ngc_globals.cpp
@@ -23,9 +23,13 @@
 int gVerboseFlag = 0;
 int gMetricUnits = 0;
 int gUnitsDefault = 1;
+
 char *gInputFilename = NULL;
 char *gOutputFilename = NULL;
 char *gConfigFilename = NULL;
+char *gGCodeHeader;
+char *gGCodeFooter;
+
 int gFeedRate = 10;
 int gSeekRate = 100;
 

--- a/src/gbl2ngc_globals.cpp
+++ b/src/gbl2ngc_globals.cpp
@@ -25,6 +25,7 @@ int gMetricUnits = 0;
 int gUnitsDefault = 1;
 char *gInputFilename = NULL;
 char *gOutputFilename = NULL;
+char *gConfigFilename = NULL;
 int gFeedRate = 10;
 int gSeekRate = 100;
 
@@ -41,6 +42,7 @@ double gZCut = -0.05;
 
 FILE *gOutStream = stdout;
 FILE *gInpStream = stdin;
+FILE *gCfgStream;
 
 double eps = 0.000001;
 double gRadius = 0.0;


### PR DESCRIPTION
This will close issue #10 .

What I've already done:

 - [x] Option --gcode-header to prepend commands to the program
 - [x] Option --gcode-footer to prepend commands to the end of the program
 - [x] Tested that the header & footer do actually get exported in the right place.

I did not assign any letter codes to the options because we are running out of letters :-) I just used the integers 2 and 3 (1 is used for other purposes by `getopt`). My overall thought was that the most important options will eventually be the ones with letter shortcuts and the "advanced options" will just have long names. Does that seem reasonable?

I haven't made options for custom commands with every G0/G1 move because I'm not familiar with what sort of commands people might need to add in those places. In shouldn't be difficult to implement, but users should be warned that if they add a custom line of G-code after every G1, it will nearly double the size of the program. @abetusk , what are your thoughts on this?

_Note:_ this PR technically depends on #12.