### PR TITLE
Fix Makefile incompatibility with clang

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -31,7 +31,7 @@ CPPFN = $(wildcard *.cpp)
 	$(CC) $(COPT) -c $< -o $@ -lm
 
 gbr2ngc: $(obj) $(hdr)
-	$(CXX) $(CXXOPT) -o $@ $^ $(CXXLIBS)
+	$(CXX) $(CXXOPT) -o $@ $(obj) $(CXXLIBS)
 
 test_gerber_interpreter: $(csrc)
 	$(CC) $(COPT2) -o $@ $^ $(COPT2)


### PR DESCRIPTION
When I tried to build this I hit this clang error because the $^ in the Makefile rule adds the header files:

    % make
    g++ -g --std=c++11 -o gbr2ngc clipper.o gbr2ngc.o gbr2ngc_aperture.o gbr2ngc_construct.o gbr2ngc_export.o gbr2ngc_globals.o gbr2ngc_heightmap.o gbr2ngc_profile.o gerber_interpreter.o string_ll.o tesexpr.o test_gerber_interpreter.o delaunay.h gerber_interpreter.h jc_voronoi.h string_ll.h tesexpr.h clipper.hpp gbr2ngc.hpp 
    clang: warning: treating 'c-header' input as 'c++-header' when in C++ mode, this behavior is deprecated [-Wdeprecated]
    clang: warning: treating 'c-header' input as 'c++-header' when in C++ mode, this behavior is deprecated [-Wdeprecated]
    clang: warning: treating 'c-header' input as 'c++-header' when in C++ mode, this behavior is deprecated [-Wdeprecated]
    clang: warning: treating 'c-header' input as 'c++-header' when in C++ mode, this behavior is deprecated [-Wdeprecated]
    clang: warning: treating 'c-header' input as 'c++-header' when in C++ mode, this behavior is deprecated [-Wdeprecated]
    clang: error: cannot specify -o when generating multiple output files
    make: *** [gbr2ngc] Error 1

Replacing $^ with $(obj) fixed it.