### PR TITLE
Document that --seek has no effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ version 0.8.3
   -o, --output output                 output file (default stdout)
   -c, --config-file config-file       configuration file (default ./gbr2ngc.ini)
   -f, --feed feed                     feed rate (default 10)
-  -s, --seek seek                     seek rate (default 100)
+  -s, --seek seek                     seek rate (default 100; currently ignored)
   -z, --zsafe zsafe                   z safe height (default 0.1 inches)
   -Z, --zcut zcut                     z cut height (default -0.05 inches)
   -2, --gcode-header gcode-header     prepend custom G-code to the beginning of the program

--- a/src/gbr2ngc.cpp
+++ b/src/gbr2ngc.cpp
@@ -100,7 +100,7 @@ char gOptionDescription[][1024] =
   "configuration file (default ./gbr2ngc.ini)",
 
   "feed rate (default 10)",
-  "seek rate (default 100)",
+  "seek rate (default 100; currently ignored)",
 
   "z safe height (default 0.1 inches)",
   "z cut height (default -0.05 inches)",


### PR DESCRIPTION
Thanks for creating gbr2ngc, this is superb software.

I had previously tried to generate g-code with pcb2gcode and FlatCAM, and was unable to get either of those programs to build or run correctly on my machine. gbr2ngc just compiled and worked out-of-the-box, so great work on that.

I was surprised to find that --seek didn't produce any effect on my g-code, and from a cursory glance it looks like it is not actually used in generating g-code. Not a big deal for me, but I thought it might help to document it so that it's clearer for others.

Cheers,
James